### PR TITLE
Update API URL to use production server

### DIFF
--- a/src/environment/environment.ts
+++ b/src/environment/environment.ts
@@ -4,7 +4,7 @@
 //local running form visual studio code and local DB
 // export const api_Url ="https://localhost:44320/api/";
 //below ai on dedicated servr
-//export const api_Url = "http://97.74.84.4/api/";
+export const api_Url = "http://97.74.84.4/api/";
 
 // export const api_Url="https://florenceApi.kulhadchaiwala.in/api/";
-export const api_Url = "http://localhost:5020/api/";
+//export const api_Url = "http://localhost:5020/api/";


### PR DESCRIPTION
Switched the active api_Url from the local server to the dedicated server at 97.74.84.4. This change points the application to the production API endpoint.